### PR TITLE
修改标点符号朗读开关名称

### DIFF
--- a/web/src/components/ConfigPanel.vue
+++ b/web/src/components/ConfigPanel.vue
@@ -9,7 +9,7 @@
             <v-divider></v-divider>
 
             <v-switch v-model="config.filter.danmu.enable" inset color="blue" label="启用弹幕朗读" aria-label="启用弹幕朗读"></v-switch>
-            <v-switch v-model="config.filter.danmu.symbolEnable" inset color="blue" label="启用标点符号朗读" aria-label="启用标点符号朗读"></v-switch>
+            <v-switch v-model="config.filter.danmu.symbolEnable" inset color="blue" label="启用纯标点符号弹幕朗读" aria-label="启用纯标点符号弹幕朗读"></v-switch>
             <v-switch v-model="config.filter.danmu.emojiEnable" inset color="blue" label="启用弹幕表情朗读" aria-label="启用弹幕表情朗读"></v-switch>
             <v-switch v-model="config.filter.danmu.deduplicate" inset color="blue" label="去除短时间内重复弹幕" aria-label="去除短时间内重复弹幕"></v-switch>
             <v-switch v-model="config.filter.danmu.isFansMedalBelongToLive" inset color="blue" label="粉丝牌必须为本直播间" aria-label="粉丝牌必须为本直播间"></v-switch>


### PR DESCRIPTION
`启用标点符号朗读`关闭时，过滤了纯标点的弹幕，其他正常弹幕任然会读出标点。我觉现在开关名称`启用标点符号朗读`可能不太直观。建议改为`启用纯标点符号弹幕朗读`，这样更能准确地描述功能。当然啦，这只是我的一个小建议。也许我们能找到一个更贴切、更直观的名字来描述这个功能。你觉得怎么样？