### PR TITLE
修复超管信息提醒功能异常

### DIFF
--- a/app/live.py
+++ b/app/live.py
@@ -100,13 +100,12 @@ class LiveMsgHandler(BaseHandler):
         liveEvent.emit('like', uid, uname)
     
     def onWarning(self, client: BLiveClient, command: dict):
-        print(msg)
         msg = command['msg']
         timeLog(f"[Warning] {msg}")
         liveEvent.emit('warning', msg, False)
 
     def onCutOff(self, client: BLiveClient, command: dict):
-        print(msg)
+        print(command)
         msg = command['msg']
         timeLog(f"[Warning] Cut Off, {msg}")
         liveEvent.emit('warning', msg, True)


### PR DESCRIPTION
您好，xqe2011，我在使用弹幕机过程中遇到了一个错误，当尝试处理包含WARNING的消息时未能成功读出内容。
```
room=0000000 _handle_command() failed, command={'cmd': 'WARNING', 'roomid': 0000000, 'msg': '禁止展示、宣传第三方平台'}
Traceback (most recent call last):
  File "G:\python\danmuji\blivedm\blivedm\clients\ws_base.py", line 492, in _handle_command
    self._handler.handle(self, command)
  File "G:\python\danmuji\blivedm\blivedm\handlers.py", line 129, in handle
    callback(self, client, command)
  File "G:\python\danmuji\app\live.py", line 247, in onWarning
    print(msg)
          ^^^
UnboundLocalError: cannot access local variable 'msg' where it is not associated with a value
```
为了修复此问题，我删除了onWarning 中打印 msg的代码，后续代码看着似乎没啥问题。onCutOff 我没有遇到，所以仍然保留了`print(command)`.